### PR TITLE
[feat] 친구요청 friend-request api 구현 완료

### DIFF
--- a/back/src/main/java/board/pjt/back/config/SecurityConfig.java
+++ b/back/src/main/java/board/pjt/back/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
         http
                 .httpBasic(AbstractHttpConfigurer::disable);
         http.authorizeHttpRequests(authorizeRequests ->
-                authorizeRequests.requestMatchers("/login/**","/friend/**", "/board/**","/status-message/**","/position/**","/feedback/**","/project-participant/**","/project-url/**","/project-stack/**","/project-attachment/**", "/board-like/**", "/comment/**", "/comment-like/**", "/user/**").permitAll()
+                authorizeRequests.requestMatchers("/login/**","/friend/**","/friend-request/**", "/board/**","/status-message/**","/position/**","/feedback/**","/project-participant/**","/project-url/**","/project-stack/**","/project-attachment/**", "/board-like/**", "/comment/**", "/comment-like/**", "/user/**").permitAll()
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .anyRequest().authenticated());
         http.addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);

--- a/back/src/main/java/board/pjt/back/controller/FriendRequestController.java
+++ b/back/src/main/java/board/pjt/back/controller/FriendRequestController.java
@@ -5,10 +5,7 @@ import board.pjt.back.common.response.ApiResponse;
 import board.pjt.back.dao.FriendRequestDao;
 import board.pjt.back.dto.PageHandler;
 import board.pjt.back.dto.common.PaginationRequestDto;
-import board.pjt.back.dto.friendRequest.FriendRequestCreateRequestDto;
-import board.pjt.back.dto.friendRequest.FriendRequestDeleteRequestDto;
-import board.pjt.back.dto.friendRequest.FriendRequestGetResponseDto;
-import board.pjt.back.dto.friendRequest.FriendRequestUpdateRequestDto;
+import board.pjt.back.dto.friendRequest.*;
 import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -48,9 +45,16 @@ public class FriendRequestController {
     }
 
     @PatchMapping("/status")
-    public ResponseEntity<ApiResponse<Void>> updateFriendRequest(@RequestBody FriendRequestUpdateRequestDto requestDto){
-        friendRequestDao.updateFriendRequest(requestDto);
+    public ResponseEntity<ApiResponse<Void>> updateFriendRequest(@AuthenticationPrincipal UserDetails userDetails, @RequestBody FriendRequestUpdateRequestDto requestDto){
+        friendRequestDao.updateFriendRequest(userDetails, requestDto);
         ApiResponse<Void> response = ApiResponse.of(SuccessCode.UPDATE_SUCCESS);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/sender-email")
+    public ResponseEntity<ApiResponse<GetSenderEmailByFriendRequestIdResponseDto>> getSenderEmailByFriendRequestId(@RequestBody GetSenderEmailByFriendRequestIdRequestDto requestDto){
+        GetSenderEmailByFriendRequestIdResponseDto senderEmail = friendRequestDao.getSenderEmailByFriendRequestId(requestDto);
+        ApiResponse<GetSenderEmailByFriendRequestIdResponseDto> response = ApiResponse.of(SuccessCode.SELECT_SUCCESS, senderEmail);
         return ResponseEntity.ok(response);
     }
 }

--- a/back/src/main/java/board/pjt/back/controller/FriendRequestController.java
+++ b/back/src/main/java/board/pjt/back/controller/FriendRequestController.java
@@ -1,0 +1,56 @@
+package board.pjt.back.controller;
+
+import board.pjt.back.common.codes.SuccessCode;
+import board.pjt.back.common.response.ApiResponse;
+import board.pjt.back.dao.FriendRequestDao;
+import board.pjt.back.dto.PageHandler;
+import board.pjt.back.dto.common.PaginationRequestDto;
+import board.pjt.back.dto.friendRequest.FriendRequestCreateRequestDto;
+import board.pjt.back.dto.friendRequest.FriendRequestDeleteRequestDto;
+import board.pjt.back.dto.friendRequest.FriendRequestGetResponseDto;
+import board.pjt.back.dto.friendRequest.FriendRequestUpdateRequestDto;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/friend-request")
+public class FriendRequestController {
+    private final FriendRequestDao friendRequestDao;
+
+    public FriendRequestController(FriendRequestDao friendRequestDao) {
+        this.friendRequestDao = friendRequestDao;
+    }
+
+    @PostMapping("/create")
+    public ResponseEntity<ApiResponse<Void>> createFriendRequest(@AuthenticationPrincipal UserDetails userDetails, @RequestBody FriendRequestCreateRequestDto requestDto){
+        requestDto.setReceiver_email(userDetails.getUsername());
+        friendRequestDao.createFriendRequest(requestDto);
+        ApiResponse<Void> response = ApiResponse.of(SuccessCode.INSERT_SUCCESS);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<ApiResponse<PageHandler<FriendRequestGetResponseDto>>> getFriendRequest(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PaginationRequestDto requestDto){
+        PageHandler<FriendRequestGetResponseDto> friendRequestGetResponseDtoPageHandler = friendRequestDao.getFriendRequest(userDetails.getUsername(), requestDto);
+        ApiResponse<PageHandler<FriendRequestGetResponseDto>> response = ApiResponse.of(SuccessCode.SELECT_SUCCESS, friendRequestGetResponseDtoPageHandler);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/")
+    public ResponseEntity<ApiResponse<Void>> deleteFriendRequest(@AuthenticationPrincipal UserDetails userDetails, @RequestBody FriendRequestDeleteRequestDto requestDto){
+        requestDto.setReceiver_email(userDetails.getUsername());
+        friendRequestDao.deleteFriendRequest(requestDto);
+        ApiResponse<Void> response = ApiResponse.of(SuccessCode.DELETE_SUCCESS);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/status")
+    public ResponseEntity<ApiResponse<Void>> updateFriendRequest(@RequestBody FriendRequestUpdateRequestDto requestDto){
+        friendRequestDao.updateFriendRequest(requestDto);
+        ApiResponse<Void> response = ApiResponse.of(SuccessCode.UPDATE_SUCCESS);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/back/src/main/java/board/pjt/back/dao/FriendRequestDao.java
+++ b/back/src/main/java/board/pjt/back/dao/FriendRequestDao.java
@@ -1,0 +1,40 @@
+package board.pjt.back.dao;
+
+import board.pjt.back.dto.PageHandler;
+import board.pjt.back.dto.common.PaginationRequestDto;
+import board.pjt.back.dto.friendRequest.FriendRequestCreateRequestDto;
+import board.pjt.back.dto.friendRequest.FriendRequestDeleteRequestDto;
+import board.pjt.back.dto.friendRequest.FriendRequestGetResponseDto;
+import board.pjt.back.dto.friendRequest.FriendRequestUpdateRequestDto;
+import board.pjt.back.mapper.FriendRequestMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class FriendRequestDao {
+    private final FriendRequestMapper friendRequestMapper;
+
+    public FriendRequestDao(FriendRequestMapper friendRequestMapper) {
+        this.friendRequestMapper = friendRequestMapper;
+    }
+    public void createFriendRequest(FriendRequestCreateRequestDto requestDto){
+        friendRequestMapper.createFriendRequest(requestDto);
+    }
+
+    public PageHandler<FriendRequestGetResponseDto> getFriendRequest(String receiver_email, PaginationRequestDto requestDto){
+        List<FriendRequestGetResponseDto> friendRequestList = friendRequestMapper.getFriendRequest(receiver_email);
+        PageHandler<FriendRequestGetResponseDto> friendRequestGetResponseDtoPageHandler = new PageHandler<>(friendRequestList.size(),requestDto.getPage(), requestDto.getPageSize());
+        friendRequestGetResponseDtoPageHandler.setContents(friendRequestList);
+        return friendRequestGetResponseDtoPageHandler;
+    }
+
+    public void deleteFriendRequest(FriendRequestDeleteRequestDto requestDto){
+        friendRequestMapper.deleteFriendRequest(requestDto);
+    }
+
+    public void updateFriendRequest(FriendRequestUpdateRequestDto requestDto){
+        friendRequestMapper.updateFriendRequestStatus(requestDto);
+
+    }
+}

--- a/back/src/main/java/board/pjt/back/dao/FriendRequestDao.java
+++ b/back/src/main/java/board/pjt/back/dao/FriendRequestDao.java
@@ -2,10 +2,13 @@ package board.pjt.back.dao;
 
 import board.pjt.back.dto.PageHandler;
 import board.pjt.back.dto.common.PaginationRequestDto;
+import board.pjt.back.dto.friend.CreateFriendRequestDto;
 import board.pjt.back.dto.friendRequest.FriendRequestCreateRequestDto;
 import board.pjt.back.dto.friendRequest.FriendRequestDeleteRequestDto;
 import board.pjt.back.dto.friendRequest.FriendRequestGetResponseDto;
 import board.pjt.back.dto.friendRequest.FriendRequestUpdateRequestDto;
+import board.pjt.back.enums.friendRequest.Status;
+import board.pjt.back.mapper.FriendMapper;
 import board.pjt.back.mapper.FriendRequestMapper;
 import org.springframework.stereotype.Service;
 
@@ -14,9 +17,10 @@ import java.util.List;
 @Service
 public class FriendRequestDao {
     private final FriendRequestMapper friendRequestMapper;
-
-    public FriendRequestDao(FriendRequestMapper friendRequestMapper) {
+    private final FriendMapper friendMapper;
+    public FriendRequestDao(FriendRequestMapper friendRequestMapper,FriendMapper friendMapper) {
         this.friendRequestMapper = friendRequestMapper;
+        this.friendMapper = friendMapper;
     }
     public void createFriendRequest(FriendRequestCreateRequestDto requestDto){
         friendRequestMapper.createFriendRequest(requestDto);
@@ -34,6 +38,11 @@ public class FriendRequestDao {
     }
 
     public void updateFriendRequest(FriendRequestUpdateRequestDto requestDto){
+        if(requestDto.getStatus() == Status.ACCEPTED){
+            CreateFriendRequestDto createFriendRequestDto = new CreateFriendRequestDto();
+//            createFriendRequestDto.setFriend_email(requestDto.get);
+//            friendMapper.createFriend();
+        }
         friendRequestMapper.updateFriendRequestStatus(requestDto);
 
     }

--- a/back/src/main/java/board/pjt/back/dto/friendRequest/FriendRequestCreateRequestDto.java
+++ b/back/src/main/java/board/pjt/back/dto/friendRequest/FriendRequestCreateRequestDto.java
@@ -1,0 +1,69 @@
+package board.pjt.back.dto.friendRequest;
+
+import board.pjt.back.enums.friendRequest.Status;
+
+import java.util.Objects;
+
+public class FriendRequestCreateRequestDto {
+    private String receiver_email;
+    private String sender_email;
+    private Status status;
+
+    public FriendRequestCreateRequestDto() {
+        this.status = Status.PENDING;
+
+    }
+
+    public FriendRequestCreateRequestDto(String receiver_email, String sender_email, Status status) {
+        this.receiver_email = receiver_email;
+        this.sender_email = sender_email;
+        this.status = Status.PENDING;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FriendRequestCreateRequestDto that = (FriendRequestCreateRequestDto) o;
+        return Objects.equals(receiver_email, that.receiver_email) && Objects.equals(sender_email, that.sender_email) && status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(receiver_email, sender_email, status);
+    }
+
+    @Override
+    public String toString() {
+        return "FriendRequestCreateRequestDto{" +
+                "receiver_email='" + receiver_email + '\'' +
+                ", sender_email='" + sender_email + '\'' +
+                ", status=" + status +
+                '}';
+    }
+
+    public String getReceiver_email() {
+        return receiver_email;
+    }
+
+    public void setReceiver_email(String receiver_email) {
+        this.receiver_email = receiver_email;
+    }
+
+    public String getSender_email() {
+        return sender_email;
+    }
+
+    public void setSender_email(String sender_email) {
+        this.sender_email = sender_email;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    // status를 외부에서 설정하지 않도록 Setter는 필요 없음 또는 private으로 설정
+    private void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/back/src/main/java/board/pjt/back/dto/friendRequest/FriendRequestDeleteRequestDto.java
+++ b/back/src/main/java/board/pjt/back/dto/friendRequest/FriendRequestDeleteRequestDto.java
@@ -1,0 +1,53 @@
+package board.pjt.back.dto.friendRequest;
+
+import java.util.Objects;
+
+public class FriendRequestDeleteRequestDto {
+    private int friend_request_id;
+    private String receiver_email;
+
+    public FriendRequestDeleteRequestDto() {
+    }
+
+    public FriendRequestDeleteRequestDto(int friend_request_id, String receiver_email) {
+        this.friend_request_id = friend_request_id;
+        this.receiver_email = receiver_email;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FriendRequestDeleteRequestDto that = (FriendRequestDeleteRequestDto) o;
+        return friend_request_id == that.friend_request_id && Objects.equals(receiver_email, that.receiver_email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(friend_request_id, receiver_email);
+    }
+
+    @Override
+    public String toString() {
+        return "FriendRequestDeleteRequestDto{" +
+                "friend_request_id=" + friend_request_id +
+                ", receiver_email='" + receiver_email + '\'' +
+                '}';
+    }
+
+    public int getFriend_request_id() {
+        return friend_request_id;
+    }
+
+    public void setFriend_request_id(int friend_request_id) {
+        this.friend_request_id = friend_request_id;
+    }
+
+    public String getReceiver_email() {
+        return receiver_email;
+    }
+
+    public void setReceiver_email(String receiver_email) {
+        this.receiver_email = receiver_email;
+    }
+}

--- a/back/src/main/java/board/pjt/back/dto/friendRequest/FriendRequestGetResponseDto.java
+++ b/back/src/main/java/board/pjt/back/dto/friendRequest/FriendRequestGetResponseDto.java
@@ -1,0 +1,78 @@
+package board.pjt.back.dto.friendRequest;
+
+import board.pjt.back.dto.friend.FriendDto;
+import board.pjt.back.enums.friendRequest.Status;
+
+import java.util.Objects;
+
+public class FriendRequestGetResponseDto {
+    private int friend_request_id;
+    private String sender_email;
+    private FriendDto friendDto;
+    private Status status;
+
+    public FriendRequestGetResponseDto() {
+    }
+
+    public FriendRequestGetResponseDto(int friend_request_id, String sender_email, FriendDto friendDto, Status status) {
+        this.friend_request_id = friend_request_id;
+        this.sender_email = sender_email;
+        this.friendDto = friendDto;
+        this.status = status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FriendRequestGetResponseDto that = (FriendRequestGetResponseDto) o;
+        return friend_request_id == that.friend_request_id && Objects.equals(sender_email, that.sender_email) && Objects.equals(friendDto, that.friendDto) && status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(friend_request_id, sender_email, friendDto, status);
+    }
+
+    @Override
+    public String toString() {
+        return "FriendRequestGetResponseDto{" +
+                "friend_request_id=" + friend_request_id +
+                ", sender_email='" + sender_email + '\'' +
+                ", friendDto=" + friendDto +
+                ", status=" + status +
+                '}';
+    }
+
+    public int getFriend_request_id() {
+        return friend_request_id;
+    }
+
+    public void setFriend_request_id(int friend_request_id) {
+        this.friend_request_id = friend_request_id;
+    }
+
+    public String getSender_email() {
+        return sender_email;
+    }
+
+    public void setSender_email(String sender_email) {
+        this.sender_email = sender_email;
+    }
+
+    public FriendDto getFriendDto() {
+        return friendDto;
+    }
+
+    public void setFriendDto(FriendDto friendDto) {
+        this.friendDto = friendDto;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/back/src/main/java/board/pjt/back/dto/friendRequest/FriendRequestUpdateRequestDto.java
+++ b/back/src/main/java/board/pjt/back/dto/friendRequest/FriendRequestUpdateRequestDto.java
@@ -1,0 +1,55 @@
+package board.pjt.back.dto.friendRequest;
+
+import board.pjt.back.enums.friendRequest.Status;
+
+import java.util.Objects;
+
+public class FriendRequestUpdateRequestDto {
+    private int friend_request_id;
+    private Status status;
+
+    public FriendRequestUpdateRequestDto() {
+    }
+
+    public FriendRequestUpdateRequestDto(int friend_request_id, Status status) {
+        this.friend_request_id = friend_request_id;
+        this.status = status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FriendRequestUpdateRequestDto that = (FriendRequestUpdateRequestDto) o;
+        return friend_request_id == that.friend_request_id && status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(friend_request_id, status);
+    }
+
+    @Override
+    public String toString() {
+        return "FriendRequestUpdateRequestDto{" +
+                "friend_request_id=" + friend_request_id +
+                ", status=" + status +
+                '}';
+    }
+
+    public int getFriend_request_id() {
+        return friend_request_id;
+    }
+
+    public void setFriend_request_id(int friend_request_id) {
+        this.friend_request_id = friend_request_id;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/back/src/main/java/board/pjt/back/dto/friendRequest/GetSenderEmailByFriendRequestIdRequestDto.java
+++ b/back/src/main/java/board/pjt/back/dto/friendRequest/GetSenderEmailByFriendRequestIdRequestDto.java
@@ -1,0 +1,42 @@
+package board.pjt.back.dto.friendRequest;
+
+import java.util.Objects;
+
+public class GetSenderEmailByFriendRequestIdRequestDto {
+    private int friend_request_id;
+
+    public GetSenderEmailByFriendRequestIdRequestDto() {
+    }
+
+    public GetSenderEmailByFriendRequestIdRequestDto(int friend_request_id) {
+        this.friend_request_id = friend_request_id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GetSenderEmailByFriendRequestIdRequestDto that = (GetSenderEmailByFriendRequestIdRequestDto) o;
+        return friend_request_id == that.friend_request_id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(friend_request_id);
+    }
+
+    @Override
+    public String toString() {
+        return "GetEmailByFriendRequestIdRequestDto{" +
+                "friend_request_id=" + friend_request_id +
+                '}';
+    }
+
+    public int getFriend_request_id() {
+        return friend_request_id;
+    }
+
+    public void setFriend_request_id(int friend_request_id) {
+        this.friend_request_id = friend_request_id;
+    }
+}

--- a/back/src/main/java/board/pjt/back/dto/friendRequest/GetSenderEmailByFriendRequestIdResponseDto.java
+++ b/back/src/main/java/board/pjt/back/dto/friendRequest/GetSenderEmailByFriendRequestIdResponseDto.java
@@ -1,0 +1,42 @@
+package board.pjt.back.dto.friendRequest;
+
+import java.util.Objects;
+
+public class GetSenderEmailByFriendRequestIdResponseDto {
+    private String sender_email;
+
+    public GetSenderEmailByFriendRequestIdResponseDto() {
+    }
+
+    public GetSenderEmailByFriendRequestIdResponseDto(String sender_email) {
+        this.sender_email = sender_email;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GetSenderEmailByFriendRequestIdResponseDto that = (GetSenderEmailByFriendRequestIdResponseDto) o;
+        return Objects.equals(sender_email, that.sender_email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sender_email);
+    }
+
+    @Override
+    public String toString() {
+        return "GetSenderEmailByFriendRequestResponseDto{" +
+                "sender_email='" + sender_email + '\'' +
+                '}';
+    }
+
+    public String getSender_email() {
+        return sender_email;
+    }
+
+    public void setSender_email(String sender_email) {
+        this.sender_email = sender_email;
+    }
+}

--- a/back/src/main/java/board/pjt/back/enums/friendRequest/Status.java
+++ b/back/src/main/java/board/pjt/back/enums/friendRequest/Status.java
@@ -1,0 +1,14 @@
+package board.pjt.back.enums.friendRequest;
+
+public enum Status {
+    PENDING("요청중: 친구 요청이 발송된 상태이며, 상대방이 아직 응답하지 않은 상태."),
+    ACCEPTED("수락: 상대방이 친구 요청을 수락한 상태."),
+    REJECTED("거절: 상대방이 친구 요청을 거절한 상태."),
+    CANCELED("요청 취소: 사용자가 친구 요청을 취소한 상태."),
+    BLOCKED("차단: 특정 사용자가 다른 사용자를 차단하여 친구 요청을 받을 수 없는 상태.");
+    private final String description;
+    Status(String description) {
+        this.description = description;
+    }
+
+}

--- a/back/src/main/java/board/pjt/back/mapper/FriendRequestMapper.java
+++ b/back/src/main/java/board/pjt/back/mapper/FriendRequestMapper.java
@@ -1,10 +1,7 @@
 package board.pjt.back.mapper;
 
 import board.pjt.back.dto.PageHandler;
-import board.pjt.back.dto.friendRequest.FriendRequestCreateRequestDto;
-import board.pjt.back.dto.friendRequest.FriendRequestDeleteRequestDto;
-import board.pjt.back.dto.friendRequest.FriendRequestGetResponseDto;
-import board.pjt.back.dto.friendRequest.FriendRequestUpdateRequestDto;
+import board.pjt.back.dto.friendRequest.*;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -16,5 +13,8 @@ public interface FriendRequestMapper {
     List<FriendRequestGetResponseDto> getFriendRequest(String receiver_email);
 
     void deleteFriendRequest(FriendRequestDeleteRequestDto dto);
-void updateFriendRequestStatus(FriendRequestUpdateRequestDto dto);
+
+    void updateFriendRequestStatus(FriendRequestUpdateRequestDto dto);
+
+    GetSenderEmailByFriendRequestIdResponseDto getSenderEmailByFriendRequestId(GetSenderEmailByFriendRequestIdRequestDto dto);
 }

--- a/back/src/main/java/board/pjt/back/mapper/FriendRequestMapper.java
+++ b/back/src/main/java/board/pjt/back/mapper/FriendRequestMapper.java
@@ -1,0 +1,20 @@
+package board.pjt.back.mapper;
+
+import board.pjt.back.dto.PageHandler;
+import board.pjt.back.dto.friendRequest.FriendRequestCreateRequestDto;
+import board.pjt.back.dto.friendRequest.FriendRequestDeleteRequestDto;
+import board.pjt.back.dto.friendRequest.FriendRequestGetResponseDto;
+import board.pjt.back.dto.friendRequest.FriendRequestUpdateRequestDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface FriendRequestMapper {
+    void createFriendRequest(FriendRequestCreateRequestDto dto);
+
+    List<FriendRequestGetResponseDto> getFriendRequest(String receiver_email);
+
+    void deleteFriendRequest(FriendRequestDeleteRequestDto dto);
+void updateFriendRequestStatus(FriendRequestUpdateRequestDto dto);
+}

--- a/back/src/main/resources/mybatis/mappers/friendRequestMapper.xml
+++ b/back/src/main/resources/mybatis/mappers/friendRequestMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="board.pjt.back.mapper.FriendRequestMapper">
+    <insert id="createFriendRequest" parameterType="FriendRequestCreateRequestDto">
+        INSERT INTO friend_request
+            (sender_email, receiver_email, status, created_at)
+        VALUE
+            (#{sender_email}, #{receiver_email}, #{status}, now())
+    </insert>
+    <select id="getFriendRequest" parameterType="String" resultType="FriendRequestGetResponseDto">
+        SELECT *
+        FROM friend_request
+        WHERE receiver_email = #{receiver_email}
+    </select>
+    <delete id="deleteFriendRequest" parameterType="FriendRequestDeleteRequestDto">
+        DELETE FROM friend_request
+        WHERE friend_request_id = #{friend_request_id}
+        AND receiver_email = #{receiver_email}
+    </delete>
+    <update id="updateFriendRequestStatus" parameterType="FriendRequestUpdateRequestDto">
+        UPDATE friend_request
+        SET status = #{status}
+        WHERE friend_request_id = #{friend_request_id}
+    </update>
+</mapper>

--- a/back/src/main/resources/mybatis/mappers/friendRequestMapper.xml
+++ b/back/src/main/resources/mybatis/mappers/friendRequestMapper.xml
@@ -3,16 +3,43 @@
         PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="board.pjt.back.mapper.FriendRequestMapper">
+    <resultMap id="getFriendRequestResult" type="FriendRequestGetResponseDto">
+        <result property="sender_email" column="sender_email"/>
+        <result property="status" column="status"/>
+        <association property="friendDto" javaType="FriendDto">
+            <association property="statusMessage" javaType="StatusMessageGetListResponseDto">
+                <id property="status_message_id" column="status_message_id"/>
+                <result property="content" column="content"/>
+                <result property="created_by" column="status_created_by"/> <!-- created_by 수정 -->
+            </association>
+            <collection property="positionList" select="getPositionList" column="sender_email"/>
+        </association>
+    </resultMap>
+    <resultMap id="positionListResult" type="PositionGetListResponseDto">
+        <result property="name" column="position_name"/>
+    </resultMap>
     <insert id="createFriendRequest" parameterType="FriendRequestCreateRequestDto">
         INSERT INTO friend_request
             (sender_email, receiver_email, status, created_at)
         VALUE
             (#{sender_email}, #{receiver_email}, #{status}, now())
     </insert>
-    <select id="getFriendRequest" parameterType="String" resultType="FriendRequestGetResponseDto">
-        SELECT *
-        FROM friend_request
+    <select id="getFriendRequest" parameterType="String" resultMap="getFriendRequestResult">
+        SELECT
+            fr.sender_email,
+            fr.status,
+            sm.status_message_id,
+            sm.content,
+            sm.created_by AS status_created_by
+        FROM friend_request fr
+        LEFT JOIN status_message sm ON fr.sender_email = sm.created_by
         WHERE receiver_email = #{receiver_email}
+    </select>
+    <select id="getPositionList" parameterType="String" resultMap="positionListResult">
+        SELECT
+            p.name AS position_name
+        FROM position p
+        WHERE p.created_by = #{sender_email}
     </select>
     <delete id="deleteFriendRequest" parameterType="FriendRequestDeleteRequestDto">
         DELETE FROM friend_request

--- a/back/src/main/resources/mybatis/mappers/friendRequestMapper.xml
+++ b/back/src/main/resources/mybatis/mappers/friendRequestMapper.xml
@@ -4,6 +4,7 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="board.pjt.back.mapper.FriendRequestMapper">
     <resultMap id="getFriendRequestResult" type="FriendRequestGetResponseDto">
+        <id property="friend_request_id" column="friend_request_id"/>
         <result property="sender_email" column="sender_email"/>
         <result property="status" column="status"/>
         <association property="friendDto" javaType="FriendDto">
@@ -26,6 +27,7 @@
     </insert>
     <select id="getFriendRequest" parameterType="String" resultMap="getFriendRequestResult">
         SELECT
+            fr.friend_request_id,
             fr.sender_email,
             fr.status,
             sm.status_message_id,
@@ -51,4 +53,9 @@
         SET status = #{status}
         WHERE friend_request_id = #{friend_request_id}
     </update>
+    <select id="getSenderEmailByFriendRequestId" parameterType="GetSenderEmailByFriendRequestIdRequestDto" resultType="GetSenderEmailByFriendRequestIdResponseDto">
+        SELECT *
+        FROM friend_request
+        WHERE friend_request_id = #{friend_request_id}
+    </select>
 </mapper>


### PR DESCRIPTION
[DONE]
1. friend-request생성
2. friend-request삭제
3. friend-request조회
4. friend-request status 수정
- status = Accpeted일때 
friend DB에 sender 과 receiver 모두 추가. (서로의 친구목록에 친구로 추가)
이후에 친구요청 데이터 삭제

- status=REJECTED 또는 status=CANCELED일 경우 
해당 데이터 삭제  

- 기타
상태명 변경